### PR TITLE
V0.4 - Changes the polaris server authentication mechanism to use web tokens

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -25,6 +25,18 @@ cc_binary(
     ],
 )
 
+# Example that starts the septentrio receiver.
+cc_binary(
+    name = "simple_polaris_client",
+    srcs = ["simple_polaris_client.cc"],
+    linkopts = ["-lboost_system"],
+    deps = [
+        "//external:gflags",
+        "//external:glog",
+        "//:polaris_asio_client",
+    ],
+)
+
 # Simple asio sepetentrio client uisng septentrio's official library.
 cc_library(
     name = "septentrio_service",

--- a/examples/asio_example.cc
+++ b/examples/asio_example.cc
@@ -14,10 +14,10 @@
 
 // Options for connecting to Polaris Server:
 DEFINE_string(
-    polaris_host, point_one::polaris::DEFAULT_POLARIS_API_URL,
+    polaris_host, point_one::polaris::DEFAULT_POLARIS_URL,
     "The Point One Navigation Polaris server tcp URI to which to connect");
 
-DEFINE_int32(polaris_port, point_one::polaris::DEFAULT_POLARIS_API_PORT,
+DEFINE_int32(polaris_port, point_one::polaris::DEFAULT_POLARIS_PORT,
              "The tcp port to which to connect");
 
 DEFINE_string(polaris_api_key, "",
@@ -137,9 +137,12 @@ int main(int argc, char* argv[]) {
     LOG(FATAL) << "You must supply a Polaris API key to connect to the server.";
     return 1;
   }
-
+  
+  point_one::polaris::PolarisConnectionSettings settings;
+  settings.host = FLAGS_polaris_host;
+  settings.port = FLAGS_polaris_port;
   point_one::polaris::PolarisAsioClient polaris_client(
-      io_loop, FLAGS_polaris_api_key, FLAGS_polaris_host, FLAGS_polaris_port);
+      io_loop, FLAGS_polaris_api_key, "asio_example", settings);
   polaris_client.SetPolarisBytesReceived(
       std::bind(&point_one::utils::SimpleAsioSerialPort::Write,
                 &serial_port_correction_forwarder, std::placeholders::_1,

--- a/examples/ntrip/ntrip_example.cc
+++ b/examples/ntrip/ntrip_example.cc
@@ -13,10 +13,10 @@
 
 // Options for connecting to Polaris Server:
 DEFINE_string(
-    polaris_host, point_one::polaris::DEFAULT_POLARIS_API_URL,
+    polaris_host, point_one::polaris::DEFAULT_POLARIS_URL,
     "The Point One Navigation Polaris server tcp URI to which to connect");
 
-DEFINE_int32(polaris_port, point_one::polaris::DEFAULT_POLARIS_API_PORT,
+DEFINE_int32(polaris_port, point_one::polaris::DEFAULT_POLARIS_PORT,
              "The tcp port to which to connect");
 
 DEFINE_string(polaris_api_key, "",
@@ -92,8 +92,11 @@ int main(int argc, char* argv[]) {
     }
 
     // Create the Polaris client.
+    point_one::polaris::PolarisConnectionSettings settings;
+    settings.host = FLAGS_polaris_host;
+    settings.port = FLAGS_polaris_port;
     point_one::polaris::PolarisAsioClient polaris_client(
-        io_loop, FLAGS_polaris_api_key, FLAGS_polaris_host, FLAGS_polaris_port);
+        io_loop, FLAGS_polaris_api_key, "ntrip_example", settings);
 
     // Initialise the server.
     ntrip::server ntrip_server(io_loop, argv[1], argv[2], argv[3]);

--- a/examples/septentrio_example.cc
+++ b/examples/septentrio_example.cc
@@ -11,10 +11,10 @@
 
 // Options for connecting to Polaris Server:
 DEFINE_string(
-    polaris_host, point_one::polaris::DEFAULT_POLARIS_API_URL,
+    polaris_host, point_one::polaris::DEFAULT_POLARIS_URL,
     "The Point One Navigation Polaris server tcp URI to which to connect");
 
-DEFINE_int32(polaris_port, point_one::polaris::DEFAULT_POLARIS_API_PORT,
+DEFINE_int32(polaris_port, point_one::polaris::DEFAULT_POLARIS_PORT,
              "The tcp port to which to connect");
 
 DEFINE_string(polaris_api_key, "",
@@ -70,8 +70,11 @@ int main(int argc, char *argv[], char *envp[]) {
   }
 
   // Create the Polaris client.
+  point_one::polaris::PolarisConnectionSettings settings;
+  settings.host = FLAGS_polaris_host;
+  settings.port = FLAGS_polaris_port;
   point_one::polaris::PolarisAsioClient polaris_client(
-      io_loop, FLAGS_polaris_api_key, FLAGS_polaris_host, FLAGS_polaris_port);
+      io_loop, FLAGS_polaris_api_key, "septentrio_example", settings);
 
   // This callback will forward RTCM correction bytes received from the server
   // to the septentrio.

--- a/include/point_one/polaris.h
+++ b/include/point_one/polaris.h
@@ -6,10 +6,10 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <cmath>
 #include <string>
 
 #include "polaris_internal.h"
@@ -26,8 +26,34 @@ static constexpr double METERS_TO_MILLIMETERS = 1000.0;
 }  // namespace
 
 // Polaris Service connection defaults.
-static const std::string DEFAULT_POLARIS_API_URL = "polaris.pointonenav.com";
-static constexpr int DEFAULT_POLARIS_API_PORT = 8088;
+static const std::string DEFAULT_POLARIS_URL = "polaris.pointonenav.com";
+static constexpr int DEFAULT_POLARIS_PORT = 8088;
+
+// Point One api for requesting access token.
+static const std::string DEFAULT_POINTONE_API_URL = "api.pointonenav.com";
+
+// How frequently to send position to polaris backend.
+static constexpr int DEFAULT_POSITION_SEND_INTERVAL_MSECS = 3000;
+
+struct PolarisConnectionSettings {
+  PolarisConnectionSettings()
+      : host(DEFAULT_POLARIS_URL),
+        port(DEFAULT_POLARIS_PORT),
+        api_host(DEFAULT_POINTONE_API_URL),
+        interval_ms(DEFAULT_POSITION_SEND_INTERVAL_MSECS) {}
+  std::string host;
+  int port;
+  std::string api_host;
+  int interval_ms;
+};
+
+static const PolarisConnectionSettings DEFAULT_CONNECTION_SETTINGS;
+
+struct PolarisAuthToken {
+  std::string access_token;
+  double issued_at;
+  double expires_in;
+};
 
 #pragma pack(1)
 
@@ -48,9 +74,12 @@ struct PositionEcef {
 
 struct PolarisPositionEcef {
   PolarisPositionEcef(const PositionEcef &ecef) {
-    x_cm = static_cast<int32_t>(std::round(ecef.pos[0] * METERS_TO_CENTIMETERS));
-    y_cm = static_cast<int32_t>(std::round(ecef.pos[1] * METERS_TO_CENTIMETERS));
-    z_cm = static_cast<int32_t>(std::round(ecef.pos[2] * METERS_TO_CENTIMETERS));
+    x_cm =
+        static_cast<int32_t>(std::round(ecef.pos[0] * METERS_TO_CENTIMETERS));
+    y_cm =
+        static_cast<int32_t>(std::round(ecef.pos[1] * METERS_TO_CENTIMETERS));
+    z_cm =
+        static_cast<int32_t>(std::round(ecef.pos[2] * METERS_TO_CENTIMETERS));
   }
 
   int32_t x_cm;
@@ -62,9 +91,7 @@ struct PolarisPositionEcef {
 // Altitude (cm)
 struct PositionLla {
   PositionLla() {}
-  PositionLla(const double pos_lla[3]) {
-    std::copy(pos_lla, pos_lla + 3, pos);
-  }
+  PositionLla(const double pos_lla[3]) { std::copy(pos_lla, pos_lla + 3, pos); }
   PositionLla(double lat_deg, double lon_deg, double alt_m) {
     pos[0] = lat_deg;
     pos[1] = lon_deg;
@@ -77,7 +104,8 @@ struct PolarisPositionLla {
   PolarisPositionLla(const PositionLla &lla) {
     lat_deg_ = static_cast<int32_t>(std::round(lla.pos[0] * 1e7));
     lon_deg_ = static_cast<int32_t>(std::round(lla.pos[1] * 1e7));
-    alt_mm_ = static_cast<int32_t>(std::round(lla.pos[2] * METERS_TO_MILLIMETERS));
+    alt_mm_ =
+        static_cast<int32_t>(std::round(lla.pos[2] * METERS_TO_MILLIMETERS));
   }
   int32_t lat_deg_;
   int32_t lon_deg_;
@@ -166,7 +194,6 @@ class PositionRequest : public PolarisRequest {
  private:
   T pos_;
 };
-
 // Request for sending ECEF postion.
 typedef PositionRequest<PolarisPositionEcef, internal::SYSTEM_ECEF>
     PositionEcefRequest;


### PR DESCRIPTION
Changes the polaris server authentication mechanism to use web tokens. Rather than transmitting the api key, the key is exchanged one time for a token which expires daily.

Additionally, this PR makes a breaking client API change to make adding additional connection parameters in the future easier.