### PR TITLE
Fixes boost dependency for NTRIP proxy.

### DIFF
--- a/examples/ntrip/BUILD
+++ b/examples/ntrip/BUILD
@@ -56,5 +56,6 @@ cc_library(
         "@boost//:asio",
         "@boost//:date_time",
         "@boost//:system",
+        "@boost//:tribool",
     ],
 )


### PR DESCRIPTION
On some builds, the transitive dependency for tribool was causing a compile error. Making this explicit.