### PR TITLE
adds embedded authentication method and examples

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -18,6 +18,7 @@ cc_library(
     name = "polaris_asio_client",
     hdrs = [
         "include/point_one/polaris_asio_client.h",
+        "include/point_one/polaris_asio_embedded_client.h",
     ],
     includes = [
         "include",
@@ -29,5 +30,6 @@ cc_library(
         "@boost//:bind",
         "@boost//:property_tree",
         "@boost//:system",
+        "@boringssl//:ssl",
     ],
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (C) Point One Navigation - All Rights Reserved
-# Written by Jason Moran <jason@pointonenav.com>, March 2019
+
 
 # Builds a sample client for connection to Point One Navigation's
 # correction service - Polaris.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 # Copyright (C) Point One Navigation - All Rights Reserved
-# Written by Jason Moran <jason@pointonenav.com>, March 2019
 
 # Dockerfile to test building of project with CMake
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,6 +28,14 @@ git_repository(
     shallow_since = "1542766478 +0900",
 )
 
+#---------------ssl --------------
+git_repository(
+    name = "boringssl",
+    commit = "87f3087d6343b89142d1191388a5885d74459df2",
+    remote = "https://boringssl.googlesource.com/boringssl",
+    shallow_since = "1586306564 +0000",
+)
+
 bind(
     name = "glog",
     actual = "@com_google_glog//:glog",

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -37,7 +37,19 @@ cc_binary(
     ],
 )
 
-# Simple asio Sepetentrio client uisng Septentrio's official library.
+# Simple example of connecting to the Polaris service using the embedded
+# keying method.
+cc_binary(
+    name = "simple_embedded_client",
+    srcs = ["simple_embedded_client.cc"],
+    deps = [
+        "//:polaris_asio_client",
+        "//external:gflags",
+        "//external:glog",
+    ],
+)
+
+# Simple asio Septentrio client uisng Septentrio's official library.
 cc_library(
     name = "septentrio_service",
     hdrs = [

--- a/examples/asio_example.cc
+++ b/examples/asio_example.cc
@@ -1,5 +1,4 @@
 // Copyright (C) Point One Navigation - All Rights Reserved
-// Written by Jason Moran <jason@pointonenav.com>, March 2019
 
 #include <iomanip>
 #include <iostream>

--- a/examples/simple_asio_serial_port.h
+++ b/examples/simple_asio_serial_port.h
@@ -1,5 +1,4 @@
 // Copyright (C) Point One Navigation - All Rights Reserved
-// Written by Jason Moran <jason@pointonenav.com>, March 2019
 
 #pragma once
 

--- a/examples/simple_embedded_client.cc
+++ b/examples/simple_embedded_client.cc
@@ -7,12 +7,18 @@
 
 #include <gflags/gflags.h>
 
-#include <point_one/polaris_asio_client.h>
+#include <point_one/polaris_asio_embedded_client.h>
 
 // Polaris options:
-DEFINE_string(polaris_api_key, "",
-              "The service API key. Contact account administrator or "
-              "sales@pointonenav.com if unknown.");
+DEFINE_string(polaris_signing_secret, "bRb1q3k4yiX4VbZxztx",
+              "The signing secret.");
+DEFINE_string(company_id, "co994711e0d78611e69dd502fd95286f33",
+              "Company ID issued by Point One.");
+DEFINE_string(unique_id, "123456789",
+              "Unique identifier of the device (serial number).");
+DEFINE_string(api_server, "api.pointonenav.com", "Address of the API server");
+DEFINE_string(polaris_server, "polaris.pointonenav.com",
+              "Address of the Polaris server");
 
 // Allows for prebuilt versions of gflags/google that don't have gflags/google
 // namespace.
@@ -38,18 +44,13 @@ int main(int argc, char* argv[]) {
   boost::asio::io_service io_loop;
   boost::asio::io_service::work work(io_loop);
 
-  // Construct a Polaris client.
-  if (FLAGS_polaris_api_key == "") {
-    LOG(FATAL) << "You must supply a Polaris API key to connect to the server.";
-    return 1;
-  }
-
   auto connection_settings = point_one::polaris::DEFAULT_CONNECTION_SETTINGS;
-  connection_settings.api_host = "api.p1beta.com";
-  connection_settings.host = "polaris.p1beta.com";
+  connection_settings.api_host = FLAGS_api_server;
+  connection_settings.host = FLAGS_polaris_server;
 
-  point_one::polaris::PolarisAsioClient polaris_client(
-      io_loop, FLAGS_polaris_api_key, "device12345", connection_settings);
+  point_one::polaris::PolarisAsioEmbeddedClient polaris_client(
+      io_loop, FLAGS_polaris_signing_secret, FLAGS_unique_id, FLAGS_company_id,
+      connection_settings);
   polaris_client.SetPolarisBytesReceived(
       std::bind(&ReceivedData, std::placeholders::_1, std::placeholders::_2));
   // Application can set position at any time to change associated beacon(s) and
@@ -64,4 +65,3 @@ int main(int argc, char* argv[]) {
 
   return 0;
 }
-

--- a/examples/simple_polaris_client.cc
+++ b/examples/simple_polaris_client.cc
@@ -45,9 +45,6 @@ int main(int argc, char* argv[]) {
   }
 
   auto connection_settings = point_one::polaris::DEFAULT_CONNECTION_SETTINGS;
-  connection_settings.api_host = "api.p1beta.com";
-  connection_settings.host = "polaris.p1beta.com";
-
   point_one::polaris::PolarisAsioClient polaris_client(
       io_loop, FLAGS_polaris_api_key, "device12345", connection_settings);
   polaris_client.SetPolarisBytesReceived(
@@ -64,4 +61,3 @@ int main(int argc, char* argv[]) {
 
   return 0;
 }
-

--- a/include/point_one/polaris.h
+++ b/include/point_one/polaris.h
@@ -1,5 +1,4 @@
 // Copyright (C) Point One Navigation - All Rights Reserved
-// Written by Jason Moran <jason@pointonenav.com>, March 2019
 
 // Encapsulation of binary protocol for connecting with the Point One Navigation
 // Polaris Server.

--- a/include/point_one/polaris_asio_embedded_client.h
+++ b/include/point_one/polaris_asio_embedded_client.h
@@ -1,6 +1,7 @@
 // Copyright (C) Point One Navigation - All Rights Reserved
 
-// Client for connecting to Polaris RTCM corrections service.
+// Client for connecting to Polaris RTCM corrections service using the
+// embedded signing authentication method
 #pragma once
 
 #include <algorithm>
@@ -17,6 +18,9 @@
 #include <string>
 #include <vector>
 
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+
 #include "glog/logging.h"
 
 #include "polaris.h"
@@ -28,30 +32,32 @@ namespace {
 constexpr int SOCKET_TIMEOUT_MS = 7000;
 }  // namespace
 
-class PolarisAsioClient {
+class PolarisAsioEmbeddedClient {
  public:
   // How long to wait before sending a new position update.  Polaris
   // Service expects receiving a message within 5 seconds.
   static constexpr int DEFAULT_POSITION_SEND_INTERVAL_MSECS = 3000;
 
-  PolarisAsioClient(boost::asio::io_service &io_service,
-                    const std::string &api_key,
-                    const std::string &unique_id = "",
+  PolarisAsioEmbeddedClient(boost::asio::io_service &io_service,
+                    const std::string &signing_secret,
+                    const std::string &unique_id,
+                    const std::string &company_id,
                     const PolarisConnectionSettings &connection_settings =
                         DEFAULT_CONNECTION_SETTINGS)
       : connection_settings_(connection_settings),
-        api_key_(api_key),
+        signing_secret_(signing_secret),
         io_service_(io_service),
         resolver_(io_service),
         socket_(io_service),
         unique_id_(unique_id),
+        company_id_(company_id),
         pos_timer_(io_service),
         reconnect_timer_(io_service, boost::posix_time::milliseconds(
                                          connection_settings.interval_ms)),
         socket_timer_(io_service,
                       boost::posix_time::milliseconds(SOCKET_TIMEOUT_MS)) {}
 
-  ~PolarisAsioClient() {
+  ~PolarisAsioEmbeddedClient() {
     polaris_bytes_received_callback_ = nullptr;
     pos_timer_.cancel();
     socket_timer_.cancel();
@@ -89,7 +95,7 @@ class PolarisAsioClient {
     }
 
     socket_.async_connect(endpoint_,
-                          boost::bind(&PolarisAsioClient::HandleConnect, this,
+                          boost::bind(&PolarisAsioEmbeddedClient::HandleConnect, this,
                                       boost::asio::placeholders::error));
   }
 
@@ -104,29 +110,16 @@ class PolarisAsioClient {
   // Store the position for resending until position is updated.  ECEF
   // variant.
   void SetPositionECEF(double x_meters, double y_meters, double z_meters) {
-    io_service_.post(boost::bind(&PolarisAsioClient::HandleSetPosition, this,
-                                 x_meters, y_meters, z_meters, true));
+    io_service_.post(boost::bind(&PolarisAsioEmbeddedClient::HandleSetPosition, this,
+                                 x_meters, y_meters, z_meters));
   }
 
-  // Send a position to Polaris, potentially updating the resulting stream.
-  // Store the position for resending until position is updated.  Latitude,
-  // longitude, altitude variant.
-  void SetPositionLLA(double lat_deg, double lon_deg, double alt_m) {
-    io_service_.post(boost::bind(&PolarisAsioClient::HandleSetPosition, this,
-                                 lat_deg, lon_deg, alt_m, false));
-  }
-
-  // Request data from a specific beacon.
-  void SetBeaconID(const std::string& beacon_id) {
-    io_service_.post(
-        boost::bind(&PolarisAsioClient::HandleSetBeacon, this, beacon_id));
-  }
 
  private:
   // The size of the read buffer.
   static constexpr int BUF_SIZE = 1024;
 
-  bool RequestToken() {
+  std::string RequestChallenge() {
     try {
       // Get a list of endpoints corresponding to the server name.
       boost::asio::ip::tcp::resolver resolver(io_service_);
@@ -144,25 +137,16 @@ class PolarisAsioClient {
       boost::asio::streambuf request;
       std::ostream request_stream(&request);
 
-      std::stringstream post_body;
-      post_body << "{\"grant_type\": \"authorization_code\", "
-                     << "\"token_type\":  \"Bearer\", "
-                     << "\"unique_id\": \"" << unique_id_ << "\", "
-                     << "\"authorization_code\": \"" << api_key_ << "\"}\r\n";
-      std::string post_body_str = post_body.str();
 
-      request_stream << "POST "
-                     << "/api/v1/auth/token"
+
+      request_stream << "GET "
+                     << "/api/v1/auth/challenge/request"
                      << " HTTP/1.1\r\n";
       request_stream << "Host: " << connection_settings_.api_host << ":80\r\n";
-      request_stream << "Content-Type: application/json\r\n";
-      request_stream << "Content-Length: " << post_body_str.size()
-                     << "\r\n";
-      request_stream << "Accept: */*\r\n";
       request_stream << "Connection: close\r\n";
       request_stream << "Cache-Control: no-cache\r\n";
       request_stream << "\r\n";
-      request_stream << post_body_str;
+      request_stream << "\r\n";
 
       // Send the request.
       boost::asio::write(socket, request);
@@ -182,7 +166,150 @@ class PolarisAsioClient {
       std::string status_message;
       std::getline(response_stream, status_message);
       if (!response_stream || http_version.substr(0, 5) != "HTTP/") {
-        LOG(ERROR) << "Invalid HTTP response to authentication token request.";
+        LOG(ERROR) << "Invalid HTTP response to challenge request.";
+        return "";
+      }
+
+      switch(status_code) {
+        case 200:
+          VLOG(1) << "Received polaris challenge.";
+          break;
+        default:
+          LOG(ERROR) << "Challenge resquest returned with status code "
+                     << status_code << ".";
+          return "";
+      }
+
+      // Process the response headers.
+      boost::asio::read_until(socket, response, "\r\n\r\n");
+      std::string header;
+      VLOG(3) << "Response:";
+      while (std::getline(response_stream, header) && header != "\r") {
+        VLOG(3) << header;
+      }
+
+      // Get the entire reply from the socket.
+      std::stringstream reply_body;
+      if (response.size() > 0) {
+        reply_body << &response;
+      }
+      boost::system::error_code error;
+      while (boost::asio::read(socket, response,
+                               boost::asio::transfer_at_least(1), error)) {
+        reply_body << &response;
+      }
+      if (error != boost::asio::error::eof) {
+        LOG(ERROR) << "Error occured while receiving challenge: "
+                   << error.message();
+        return "";
+      }
+
+      std::string challenge = "";
+      try {
+        // Parse json.
+        boost::property_tree::ptree pt;
+        boost::property_tree::read_json(reply_body, pt);
+        challenge = pt.get<std::string>("challenge");
+        VLOG(3) << "Challenge is : " << challenge;
+      } catch (std::exception &e) {
+        LOG(ERROR) << "Exception in parsing challenge request response: " << e.what();
+        return "";
+      }
+
+      return challenge;
+    } catch (std::exception &e) {
+      LOG(ERROR) << "Exception: " << e.what();
+    }
+    return "";
+  }
+
+  std::string BuildChallengeSignature(std::string challenge, uint64_t time) {
+    // concatenate the string and calculate the message digest
+
+    // challenge| timestamp | company_id | serial_number
+    std::stringstream ss;
+    ss << challenge << std::to_string(time) << company_id_ << unique_id_;
+
+    unsigned int HMAC_SHA512_HASH_LEN = 64;
+    uint8_t buf[HMAC_SHA512_HASH_LEN];
+    std::string message = ss.str();
+    HMAC_CTX hmac_ctx;
+    HMAC_CTX_init(&hmac_ctx);
+    HMAC_Init_ex(&hmac_ctx, (void *)signing_secret_.data(),
+                 signing_secret_.length(), EVP_sha512(), NULL);
+    HMAC_Update(&hmac_ctx, (uint8_t *)message.data(), message.length());
+    HMAC_Final(&hmac_ctx, buf, &HMAC_SHA512_HASH_LEN);
+    unsigned char encodedData[128] = {};  // this is beyond safe, the max length
+                                          // of this is 1.25 * the HASH LEN
+
+    EVP_EncodeBlock(encodedData, buf, HMAC_SHA512_HASH_LEN);
+    std::string output((char *)encodedData);
+    VLOG(2) << "Challenge Response Signature :" << std::endl << output;
+    return output;
+  }
+
+  bool GetAuthToken(std::string challenge, uint64_t time, std::string signature) {
+    try {
+      // Get a list of endpoints corresponding to the server name.
+      boost::asio::ip::tcp::resolver resolver(io_service_);
+      boost::asio::ip::tcp::resolver::query query(connection_settings_.api_host,
+                                                  "http");
+      boost::asio::ip::tcp::resolver::iterator endpoint_iterator =
+              resolver.resolve(query);
+
+      // Try each endpoint until we successfully establish a connection.
+      boost::asio::ip::tcp::socket socket(io_service_);
+      boost::asio::connect(socket, endpoint_iterator);
+
+      // Form the request. We specify the "Connection: close" header so that the
+      // server will close the socket after transmitting the response.
+      boost::asio::streambuf request;
+      std::ostream request_stream(&request);
+
+
+      std::stringstream post_body;
+      post_body << "{\"challenge\": \"" << challenge << "\", "
+                << "\"timestamp\":  \"" << std::to_string(time) << "\", "
+                << "\"company_id\": \"" << company_id_ << "\", "
+                << "\"unique_id\": \"" << unique_id_ << "\", "
+                << "\"signature\": \"" << signature << "\""
+                << "}\r\n";
+      std::string post_body_str = post_body.str();
+      LOG(INFO) << " JSON " << std::endl << post_body_str;
+
+      request_stream << "POST "
+                     << "/api/v1/auth/challenge/response"
+                     << " HTTP/1.1\r\n";
+      request_stream << "Host: " << connection_settings_.api_host << ":80\r\n";
+      request_stream << "Content-Type: application/json\r\n";
+      request_stream << "Content-Length: " << post_body_str.size()
+                     << "\r\n";
+      request_stream << "Accept: */*\r\n";
+      request_stream << "Connection: close\r\n";
+      request_stream << "Cache-Control: no-cache\r\n";
+      request_stream << "\r\n";
+      request_stream << post_body_str;
+
+
+      // Send the request.
+      boost::asio::write(socket, request);
+
+      // Read the response status line. The response streambuf will
+      // automatically grow to accommodate the entire line. The growth may be
+      // limited by passing a maximum size to the streambuf constructor.
+      boost::asio::streambuf response;
+      boost::asio::read_until(socket, response, "\r\n");
+
+      // Check that response is OK.
+      std::istream response_stream(&response);
+      std::string http_version;
+      response_stream >> http_version;
+      unsigned int status_code;
+      response_stream >> status_code;
+      std::string status_message;
+      std::getline(response_stream, status_message);
+      if (!response_stream || http_version.substr(0, 5) != "HTTP/") {
+        LOG(ERROR) << "Invalid HTTP response to challenge response.";
         return false;
       }
 
@@ -192,10 +319,10 @@ class PolarisAsioClient {
           break;
         case 403:
           LOG(ERROR) << "Received an authentication forbidden (403) response "
-                        "from Polaris. Please check your API key.";
+                        "from Polaris. Please check challenge.";
           return false;
         default:
-          LOG(ERROR) << "Authentication response returned with status code "
+          LOG(ERROR) << "Authentication challenge response returned with status code "
                      << status_code << ".";
           return false;
       }
@@ -267,9 +394,12 @@ class PolarisAsioClient {
   void SendAuth() {
     VLOG(1) << "Authenticating with service using auth token.";
     if (api_token_.access_token.empty()) {
-      if (!RequestToken()) {
-        // Token request failures are fatal - probably an invalid API key. Don't
-        // schedule a reconnect.
+      std::string challenge  = RequestChallenge();
+      LOG(INFO) << " GOT CHALLENGE " << challenge;
+      uint64_t time = std::time(0);
+      std::string signature = BuildChallengeSignature(challenge, time);
+      if (!GetAuthToken(challenge, time, signature)) {
+        LOG(WARNING) << "Failed to get the auth token exchange!";
         return;
       }
     }
@@ -281,7 +411,7 @@ class PolarisAsioClient {
     std::unique_lock<std::recursive_mutex> guard(lock_);
     boost::asio::async_write(
         socket_, boost::asio::buffer(*buf),
-        boost::bind(&PolarisAsioClient::HandleAuthTokenWrite, this, buf,
+        boost::bind(&PolarisAsioEmbeddedClient::HandleAuthTokenWrite, this, buf,
                     boost::asio::placeholders::error));
   }
 
@@ -310,12 +440,9 @@ class PolarisAsioClient {
 
     if (stream_selection_source_ == StreamSelectionSource::POSITION) {
       pos_timer_.expires_from_now(boost::posix_time::milliseconds(0));
-      pos_timer_.async_wait(boost::bind(&PolarisAsioClient::PositionTimer, this,
+      pos_timer_.async_wait(boost::bind(&PolarisAsioEmbeddedClient::PositionTimer, this,
                                         boost::asio::placeholders::error));
-    } else if (stream_selection_source_ == StreamSelectionSource::BEACON) {
-      HandleSetBeacon(beacon_id_);
     }
-
     VLOG(2) << "Scheduling initial socket read.";
     ScheduleAsyncReadWithTimeout();
   }
@@ -344,14 +471,14 @@ class PolarisAsioClient {
     socket_timer_.expires_from_now(
         boost::posix_time::milliseconds(SOCKET_TIMEOUT_MS));
     socket_timer_.async_wait(
-        boost::bind(&PolarisAsioClient::HandleSocketTimeout, this,
+        boost::bind(&PolarisAsioEmbeddedClient::HandleSocketTimeout, this,
                     boost::asio::placeholders::error));
 
     // Read more bytes if they are available.
     std::unique_lock<std::recursive_mutex> guard(lock_);
     boost::asio::async_read(
         socket_, boost::asio::buffer(buf_), boost::asio::transfer_at_least(1),
-        boost::bind(&PolarisAsioClient::HandleSocketRead, this,
+        boost::bind(&PolarisAsioEmbeddedClient::HandleSocketRead, this,
                     boost::asio::placeholders::error,
                     boost::asio::placeholders::bytes_transferred));
   }
@@ -366,7 +493,7 @@ class PolarisAsioClient {
       reconnect_timer_.expires_from_now(
           boost::posix_time::milliseconds(wait_ms));
       reconnect_timer_.async_wait(
-          boost::bind(&PolarisAsioClient::HandleReconnectTimeout, this,
+          boost::bind(&PolarisAsioEmbeddedClient::HandleReconnectTimeout, this,
                       boost::asio::placeholders::error));
       reconnect_set_ = true;
     } else {
@@ -395,20 +522,15 @@ class PolarisAsioClient {
   }
 
   // Sets the position of the client for future broadcasting.
-  void HandleSetPosition(double a, double b, double c, bool is_ecef) {
-    pos_is_ecef_ = is_ecef;
-    if (is_ecef) {
-      ecef_pos_ = PositionEcef(a, b, c);
-    } else {
-      lla_pos_ = PositionLla(a, b, c);
-    }
+  void HandleSetPosition(double a, double b, double c) {
+    ecef_pos_ = PositionEcef(a, b, c);
 
     if (stream_selection_source_ != StreamSelectionSource::POSITION) {
       VLOG(1) << "Scheduling first position update.";
       stream_selection_source_ = StreamSelectionSource::POSITION;
       if (connected_) {
         pos_timer_.expires_from_now(boost::posix_time::milliseconds(0));
-        pos_timer_.async_wait(boost::bind(&PolarisAsioClient::PositionTimer,
+        pos_timer_.async_wait(boost::bind(&PolarisAsioEmbeddedClient::PositionTimer,
                                           this,
                                           boost::asio::placeholders::error));
       }
@@ -428,7 +550,7 @@ class PolarisAsioClient {
     VLOG(4) << "Scheduling position timer.";
     pos_timer_.expires_from_now(
         boost::posix_time::milliseconds(connection_settings_.interval_ms));
-    pos_timer_.async_wait(boost::bind(&PolarisAsioClient::PositionTimer, this,
+    pos_timer_.async_wait(boost::bind(&PolarisAsioEmbeddedClient::PositionTimer, this,
                                       boost::asio::placeholders::error));
   }
 
@@ -437,11 +559,10 @@ class PolarisAsioClient {
     VLOG(2) << "Sending position update.";
 
     std::unique_ptr<PolarisRequest> request;
-    if (pos_is_ecef_) {
-      request.reset(new PositionEcefRequest(ecef_pos_));
-    } else {
-      request.reset(new PositionLlaRequest(lla_pos_));
-    }
+
+    request.reset(new PositionEcefRequest(ecef_pos_));
+    VLOG(2) << "Position is ECEF: X:" << ecef_pos_.pos[0] <<" Y:" << ecef_pos_.pos[1] << " Z:" << ecef_pos_.pos[2];
+
 
     auto buf = std::make_shared<std::vector<uint8_t>>(request->GetSize());
     request->Serialize(buf->data());
@@ -449,32 +570,10 @@ class PolarisAsioClient {
     std::unique_lock<std::recursive_mutex> guard(lock_);
     boost::asio::async_write(
         socket_, boost::asio::buffer(*buf),
-        boost::bind(&PolarisAsioClient::HandleResponse, this,
+        boost::bind(&PolarisAsioEmbeddedClient::HandleResponse, this,
                     boost::asio::placeholders::error, "position update"));
   }
 
-  // Issue a request for the specified beacon.
-  void HandleSetBeacon(const std::string& beacon_id) {
-    if (stream_selection_source_ == StreamSelectionSource::POSITION) {
-      pos_timer_.cancel();
-    }
-
-    stream_selection_source_ = StreamSelectionSource::BEACON;
-    beacon_id_ = beacon_id;
-
-    if (connected_) {
-      LOG(INFO) << "Sending request for beacon '" << beacon_id << "'.";
-      BeaconRequest request(beacon_id);
-      auto buf = std::make_shared<std::vector<uint8_t>>(request.GetSize());
-      request.Serialize(buf->data());
-
-      std::unique_lock<std::recursive_mutex> guard(lock_);
-      boost::asio::async_write(
-          socket_, boost::asio::buffer(*buf),
-          boost::bind(&PolarisAsioClient::HandleResponse, this,
-                      boost::asio::placeholders::error, "beacon request"));
-    }
-  }
 
   // Schedule a service reconnect if a request fails to send.
   void HandleResponse(const boost::system::error_code &err,
@@ -489,7 +588,7 @@ class PolarisAsioClient {
     }
   }
 
-  enum class StreamSelectionSource { NONE, BEACON, POSITION };
+  enum class StreamSelectionSource { NONE, POSITION };
 
   // Synchronization for the socket.
   std::recursive_mutex lock_;
@@ -497,9 +596,10 @@ class PolarisAsioClient {
   // Settings for reaching polaris services.
   const PolarisConnectionSettings connection_settings_;
 
-  // The serial number of the device for connecting with Polaris.
-  std::string api_key_;
+  // The signing secret for signing challenge responses
+  std::string signing_secret_;
 
+  // The issued token after authenticated with Polaris
   PolarisAuthToken api_token_;
 
   // The asio event loop service.
@@ -521,9 +621,10 @@ class PolarisAsioClient {
   // framed.
   std::function<void(uint8_t *, uint16_t)> polaris_bytes_received_callback_;
 
-  // Optionally a unique id that can be used to aid in debugging when sharing an api key
-  // with multiple clients.
+  // The unique_id and company_id are required to authenticate a device issued by a paritcular
+  // company. Often the unique_id is a units permanent serial number.
   std::string unique_id_;
+  std::string company_id_;
 
   // A deadline time for resending postion.
   boost::asio::deadline_timer pos_timer_;
@@ -546,17 +647,10 @@ class PolarisAsioClient {
   // The typeof input used to select a data stream.
   StreamSelectionSource stream_selection_source_ = StreamSelectionSource::NONE;
 
-  // Whether to send last position as ecef or meters.
-  bool pos_is_ecef_ = true;
-
   // Last position in ECEF XYZ meters.
   PositionEcef ecef_pos_;
 
-  // Last position in Latitude(deg), Longitude(deg), alt(m).
-  PositionLla lla_pos_;
 
-  // The desired beacon ID.
-  std::string beacon_id_;
 };
 
 }  // namespace polaris

--- a/include/point_one/polaris_internal.h
+++ b/include/point_one/polaris_internal.h
@@ -1,5 +1,4 @@
 // Copyright (C) Point One Navigation - All Rights Reserved
-// Written by Jason Moran <jason@pointonenav.com>, March 2019
 
 // Encapsulation of binary protocol for connecting with the Point One Navigation
 // Polaris Server.


### PR DESCRIPTION
This adds support for an "embedded" authentication scheme in where devices can provide an internal serial number, signed by a shared secret, to authenticate to receive Polaris corrections