### PR TITLE
Removed C++ DEFAULT_ENDPOINT_* variables.

### DIFF
--- a/examples/ntrip/ntrip_example.cc
+++ b/examples/ntrip/ntrip_example.cc
@@ -27,11 +27,12 @@ using namespace point_one::polaris;
 
 // Options for connecting to Polaris Server:
 DEFINE_string(
-    polaris_host, DEFAULT_ENDPOINT_URL,
-    "The Polaris corrections endpoint URL to be used.");
+    polaris_host, "",
+    "Specify an alternate Polaris corrections endpoint URL to be used.");
 
-DEFINE_int32(polaris_port, DEFAULT_ENDPOINT_PORT,
-             "The TCP port of the Polaris corrections endpoint.");
+DEFINE_int32(polaris_port, 0,
+             "Specify an alternate TCP port for the Polaris corrections "
+             "endpoint.");
 
 DEFINE_string(polaris_api_key, "",
               "The service API key. Contact account administrator or "

--- a/src/point_one/polaris/polaris_client.cc
+++ b/src/point_one/polaris/polaris_client.cc
@@ -60,6 +60,8 @@ PolarisClient::PolarisClient(const std::string& api_key,
     : max_reconnect_attempts_(max_reconnect_attempts),
       api_key_(api_key),
       unique_id_(unique_id) {
+  SetPolarisEndpoint();
+
   polaris_.SetRTCMCallback([&](const uint8_t* buffer, size_t size_bytes) {
     std::unique_lock<std::recursive_mutex> lock(mutex_);
     VLOG(2) << "Received " << size_bytes << " bytes.";
@@ -98,8 +100,22 @@ void PolarisClient::SetAuthToken(const std::string& auth_token) {
 void PolarisClient::SetPolarisEndpoint(const std::string& endpoint_url,
                                        int endpoint_port) {
   std::unique_lock<std::recursive_mutex> lock(mutex_);
-  endpoint_url_ = endpoint_url;
-  endpoint_port_ = endpoint_port;
+  if (endpoint_url.empty()) {
+    endpoint_url_ = POLARIS_ENDPOINT_URL;
+  } else {
+    endpoint_url_ = endpoint_url;
+  }
+
+  if (endpoint_port == 0) {
+    endpoint_port_ =
+#ifdef POLARIS_USE_TLS
+        POLARIS_ENDPOINT_TLS_PORT;
+#else
+        POLARIS_ENDPOINT_PORT;
+#endif
+  } else {
+    endpoint_port_ = endpoint_port;
+  }
 }
 
 /******************************************************************************/

--- a/src/point_one/polaris/polaris_client.h
+++ b/src/point_one/polaris/polaris_client.h
@@ -34,8 +34,8 @@ class PolarisClient {
 
   void SetAuthToken(const std::string& auth_token);
 
-  void SetPolarisEndpoint(const std::string& endpoint_url,
-                          int endpoint_port = DEFAULT_ENDPOINT_PORT);
+  void SetPolarisEndpoint(const std::string& endpoint_url = "",
+                          int endpoint_port = 0);
 
   void SetMaxReconnects(int max_reconnect_attempts);
 
@@ -65,8 +65,8 @@ class PolarisClient {
 
   std::function<void(const uint8_t* buffer, size_t size_bytes)> callback_;
 
-  std::string endpoint_url_ = POLARIS_ENDPOINT_URL;
-  int endpoint_port_ = POLARIS_ENDPOINT_TLS_PORT;
+  std::string endpoint_url_;
+  int endpoint_port_ = 0;
 
   bool auth_valid_ = false;
   bool connected_ = false;

--- a/src/point_one/polaris/polaris_interface.cc
+++ b/src/point_one/polaris/polaris_interface.cc
@@ -8,9 +8,6 @@
 
 using namespace point_one::polaris;
 
-const std::string point_one::polaris::DEFAULT_ENDPOINT_URL =
-    POLARIS_ENDPOINT_URL;
-
 /******************************************************************************/
 PolarisInterface::PolarisInterface() {
   Polaris_Init(&context_);

--- a/src/point_one/polaris/polaris_interface.h
+++ b/src/point_one/polaris/polaris_interface.h
@@ -14,14 +14,6 @@
 namespace point_one {
 namespace polaris {
 
-extern const std::string DEFAULT_ENDPOINT_URL;
-static constexpr int DEFAULT_ENDPOINT_PORT =
-#ifdef POLARIS_USE_TLS
-  POLARIS_ENDPOINT_TLS_PORT;
-#else
-  POLARIS_ENDPOINT_PORT;
-#endif
-
 /**
  * @brief C++ wrapper class for the Polaris Client C library.
  */


### PR DESCRIPTION
These suffered from static initializer order issues in some cases, and the port
variable forced the user to define POLARIS_USE_TLS correctly.

A better solution is to allow the user to request the default URL and port by
specifying "" and 0 respectively.