### PR TITLE
Fixed handling of upstream disconnects.

### DIFF
--- a/c/src/point_one/polaris/polaris.h
+++ b/c/src/point_one/polaris/polaris.h
@@ -58,7 +58,7 @@
  *        single receive call (@ref Polaris_Work()).
  */
 #ifndef POLARIS_RECV_TIMEOUT_MS
-# define POLARIS_RECV_TIMEOUT_MS 1000
+# define POLARIS_RECV_TIMEOUT_MS 5000
 #endif
 
 /**

--- a/src/point_one/polaris/polaris_client.h
+++ b/src/point_one/polaris/polaris_client.h
@@ -49,9 +49,9 @@ class PolarisClient {
 
   void RequestBeacon(const std::string& beacon_id);
 
-  void Run(double timeout_sec = 15.0);
+  void Run(double timeout_sec = 30.0);
 
-  void RunAsync(double timeout_sec = 15.0);
+  void RunAsync(double timeout_sec = 30.0);
 
   void Disconnect();
 


### PR DESCRIPTION
# Changes
- Increased the socket receive timeout to better allow for variable data latency
- Increased the default connection timeout in the C++ client

# Fixes
- Fixed handling of upstream socket disconnects in POSIX (behavioral difference between POSIX and FreeRTOS)