### PR TITLE
Corrected read timeout handling for TLS and handling of errors during authentication.

### DIFF
--- a/c/examples/connection_retry.c
+++ b/c/examples/connection_retry.c
@@ -27,7 +27,9 @@ void HandleSignal(int sig) {
 
 int main(int argc, const char* argv[]) {
   if (argc < 2 || argc > 4) {
-    P1_fprintf(stderr, "Usage: %s API_KEY [UNIQUE_ID] [LOG_LEVEL]\n", argv[0]);
+    P1_fprintf(stderr,
+               "Usage: %s API_KEY [UNIQUE_ID] [LOG_LEVEL (1=debug, 2=trace)]\n",
+               argv[0]);
     return 1;
   }
 

--- a/c/examples/simple_polaris_client.c
+++ b/c/examples/simple_polaris_client.c
@@ -27,7 +27,9 @@ void HandleSignal(int sig) {
 
 int main(int argc, const char* argv[]) {
   if (argc < 2 || argc > 4) {
-    P1_fprintf(stderr, "Usage: %s API_KEY [UNIQUE_ID] [LOG_LEVEL]\n", argv[0]);
+    P1_fprintf(stderr,
+               "Usage: %s API_KEY [UNIQUE_ID] [LOG_LEVEL (1=debug, 2=trace)]\n",
+               argv[0]);
     return 1;
   }
 

--- a/c/src/point_one/polaris/polaris.c
+++ b/c/src/point_one/polaris/polaris.c
@@ -557,6 +557,11 @@ int Polaris_Work(PolarisContext_t* context) {
     // Did we hit a read timeout? This is normal behavior (e.g., brief loss of
     // cell service) and is not considered an error. Most receivers can handle
     // small gaps in corrections data. We do not close the socket here.
+    //
+    // Note that in this context the timeout is the socket receive timeout
+    // (POLARIS_RECV_TIMEOUT_MS; typically a few seconds). This is not the same
+    // as the longer connection timeout used by Polaris_Run() to decide if the
+    // connection was lost upstream (typically 30 seconds or longer).
 #ifdef POLARIS_USE_TLS
     int ssl_error = SSL_get_error(context->ssl, bytes_read);
     if (ssl_error == SSL_ERROR_WANT_READ || ssl_error == SSL_ERROR_WANT_WRITE) {

--- a/c/src/point_one/polaris/polaris.c
+++ b/c/src/point_one/polaris/polaris.c
@@ -212,6 +212,7 @@ int Polaris_Authenticate(PolarisContext_t* context, const char* api_key,
 
   P1_DebugPrint("Sending auth request. [api_key=%s, unique_id=%s]\n", api_key,
              unique_id);
+  context->auth_token[0] = '\0';
 #ifdef POLARIS_USE_TLS
   int status_code =
       SendPOSTRequest(context, POLARIS_API_URL, 443, "/api/v1/auth/token",

--- a/c/src/point_one/polaris/polaris.c
+++ b/c/src/point_one/polaris/polaris.c
@@ -368,6 +368,8 @@ int Polaris_ConnectWithoutAuth(PolarisContext_t* context,
     }
   }
 
+  context->authenticated = 1;
+
   return POLARIS_SUCCESS;
 }
 

--- a/c/src/point_one/polaris/polaris.c
+++ b/c/src/point_one/polaris/polaris.c
@@ -510,11 +510,16 @@ int Polaris_RequestBeacon(PolarisContext_t* context, const char* beacon_id) {
 
 /******************************************************************************/
 int Polaris_Work(PolarisContext_t* context) {
+  // The following should be unlikely to happen, but we call CloseSocket() just
+  // in case this function is called after Polaris_Disconnect() to clean up the
+  // SSL session.
   if (context->disconnected) {
     P1_DebugPrint("Connection terminated by user request.\n");
+    CloseSocket(context, 1);
     return POLARIS_CONNECTION_CLOSED;
   } else if (context->socket == P1_INVALID_SOCKET) {
     P1_Print("Error: Polaris connection not currently open.\n");
+    CloseSocket(context, 1);
     return POLARIS_SOCKET_ERROR;
   }
 
@@ -604,8 +609,16 @@ int Polaris_Work(PolarisContext_t* context) {
 
 /******************************************************************************/
 int Polaris_Run(PolarisContext_t* context, int connection_timeout_ms) {
-  if (context->socket == P1_INVALID_SOCKET) {
+  // The following should be unlikely to happen, but we call CloseSocket() just
+  // in case this function is called after Polaris_Disconnect() to clean up the
+  // SSL session.
+  if (context->disconnected) {
+    P1_DebugPrint("Connection terminated by user request.\n");
+    CloseSocket(context, 1);
+    return POLARIS_SUCCESS;
+  } else if (context->socket == P1_INVALID_SOCKET) {
     P1_Print("Error: Polaris connection not currently open.\n");
+    CloseSocket(context, 1);
     return POLARIS_SOCKET_ERROR;
   }
 

--- a/c/src/point_one/polaris/polaris.c
+++ b/c/src/point_one/polaris/polaris.c
@@ -736,6 +736,12 @@ static int OpenSocket(PolarisContext_t* context, const char* endpoint_url,
     P1_Print("Error: socket already open.\n");
     return POLARIS_ERROR;
   }
+#ifdef POLARIS_USE_TLS
+  else if (context->ssl_ctx != NULL || context->ssl != NULL) {
+    P1_Print("Error: SSL context not freed.\n");
+    return POLARIS_ERROR;
+  }
+#endif
 
 #ifdef POLARIS_USE_TLS
   // Configure TLS.

--- a/c/src/point_one/polaris/polaris.c
+++ b/c/src/point_one/polaris/polaris.c
@@ -557,7 +557,12 @@ int Polaris_Work(PolarisContext_t* context) {
     // Did we hit a read timeout? This is normal behavior (e.g., brief loss of
     // cell service) and is not considered an error. Most receivers can handle
     // small gaps in corrections data. We do not close the socket here.
+#ifdef POLARIS_USE_TLS
+    int ssl_error = SSL_get_error(context->ssl, bytes_read);
+    if (ssl_error == SSL_ERROR_WANT_READ || ssl_error == SSL_ERROR_WANT_WRITE) {
+#else
     if (errno == EAGAIN || errno == ETIMEDOUT) {
+#endif
       P1_DebugPrint("Socket timed out.\n");
       return 0;
     }

--- a/c/src/point_one/polaris/polaris.c
+++ b/c/src/point_one/polaris/polaris.c
@@ -733,7 +733,7 @@ static int OpenSocket(PolarisContext_t* context, const char* endpoint_url,
                       int endpoint_port) {
   // Is the connection already open?
   if (context->socket != P1_INVALID_SOCKET) {
-    P1_Print("Error socket already open.\n");
+    P1_Print("Error: socket already open.\n");
     return POLARIS_ERROR;
   }
 
@@ -750,7 +750,7 @@ static int OpenSocket(PolarisContext_t* context, const char* endpoint_url,
   SSL_CTX_set_options(context->ssl_ctx, SSL_OP_NO_TLSv1);
 
   if (context->ssl_ctx == NULL) {
-    P1_Print("SSL Context Failed to Initialize.\n");
+    P1_Print("SSL context failed to initialize.\n");
     return POLARIS_ERROR;
   }
 #endif

--- a/c/src/point_one/polaris/polaris.c
+++ b/c/src/point_one/polaris/polaris.c
@@ -292,6 +292,7 @@ int Polaris_ConnectTo(PolarisContext_t* context, const char* endpoint_url,
 
   // Connect to the corrections endpoint.
   context->disconnected = 0;
+  context->authenticated = 0;
   int ret = OpenSocket(context, endpoint_url, endpoint_port);
   if (ret != POLARIS_SUCCESS) {
     P1_Print("Error connecting to corrections endpoint: tcp://%s:%d.\n",
@@ -339,6 +340,7 @@ int Polaris_ConnectWithoutAuth(PolarisContext_t* context,
 
   // Connect to the corrections endpoint.
   context->disconnected = 0;
+  context->authenticated = 0;
   ret = OpenSocket(context, endpoint_url, endpoint_port);
   if (ret != POLARIS_SUCCESS) {
     P1_Print("Error connecting to corrections endpoint: tcp://%s:%d.\n",
@@ -855,6 +857,12 @@ void CloseSocket(PolarisContext_t* context, int destroy_context) {
     context->ssl_ctx = NULL;
   }
 #endif
+
+  context->authenticated = 0;
+
+  // Note: We do not clear disconnected here since it is used to determine
+  // the return value in Polaris_Run() _after_ Polaris_Work() has returned and
+  // may have closed the socket.
 }
 
 /******************************************************************************/

--- a/c/src/point_one/polaris/polaris.h
+++ b/c/src/point_one/polaris/polaris.h
@@ -404,6 +404,10 @@ int Polaris_Work(PolarisContext_t* context);
  * If the specified timeout has elapsed since the last time data was received,
  * the connection will be considered lost and the function will return.
  *
+ * @post
+ * Unlike @ref Polaris_Work(), a value of @ref POLARIS_TIMED_OUT here indicates
+ * the connection has been lost, and the socket will be closed on return.
+ *
  * @param context The Polaris context to be used.
  * @param connection_timeout_ms The maximum elapsed time (in ms) between reads,
  *        after which the connection is considered lost.

--- a/c/src/point_one/polaris/polaris.h
+++ b/c/src/point_one/polaris/polaris.h
@@ -370,9 +370,9 @@ int Polaris_RequestBeacon(PolarisContext_t* context, const char* beacon_id);
  *
  * @param context The Polaris context to be used.
  *
- * @return The number of received bytes, or 0 if the timeout elapsed or @ref
- *         Polaris_Disconnect() was called without receiving data.
- * @return @ref POLARIS_CONNECTION_CLOSED if the connection was closed remotely.
+ * @return The number of received bytes, or 0 if the timeout elapsed.
+ * @return @ref POLARIS_CONNECTION_CLOSED if the connection was closed remotely
+ *         or by calling @ref Polaris_Disconnect().
  * @return @ref POLARIS_FORBIDDEN if the connection is closed before any data
  *         is received, indicating an authentication failure (invalid or expired
  *         access token).
@@ -395,7 +395,9 @@ int Polaris_Work(PolarisContext_t* context);
  *        after which the connection is considered lost.
  *
  * @return @ref POLARIS_SUCCESS if the connection was closed by a call to @ref
- *         Polaris_Disconnect().
+ *         Polaris_Disconnect(). Note that this differs from @ref
+ *         Polaris_Work(), which returns @ref POLARIS_CONNECTION_CLOSED for
+ *         both remote and local connection termination.
  * @return @ref POLARIS_CONNECTION_CLOSED if the connection was closed remotely.
  * @return @ref POLARIS_TIMED_OUT if no data was received for the specified
  *         timeout.

--- a/c/src/point_one/polaris/polaris.h
+++ b/c/src/point_one/polaris/polaris.h
@@ -359,6 +359,15 @@ int Polaris_RequestBeacon(PolarisContext_t* context, const char* beacon_id);
  * POLARIS_RECV_TIMEOUT_MS elapses. If @ref Polaris_Disconnect() is called, this
  * function will return immediately.
  *
+ * @warning
+ * Important: A read timeout is a normal occurrence and is not considered an
+ * error condition. Read timeouts can happen occasionally due to intermittent
+ * internet connections (e.g., client vehicle losing cell coverage briefly).
+ * Most GNSS receivers can tolerate small gaps in corrections data. The socket
+ * will _not_ be closed on a read timeout (return 0). The calling code must
+ * call `Polaris_Disconnect()` to close the socket before attempting to
+ * reconnect or reauthenticate.
+ *
  * @note
  * There is no guarantee that a data block contains a complete RTCM message, or
  * starts on an RTCM message boundary.

--- a/c/src/point_one/polaris/polaris.h
+++ b/c/src/point_one/polaris/polaris.h
@@ -359,14 +359,18 @@ int Polaris_RequestBeacon(PolarisContext_t* context, const char* beacon_id);
  * POLARIS_RECV_TIMEOUT_MS elapses. If @ref Polaris_Disconnect() is called, this
  * function will return immediately.
  *
+ * If an error occurs and this function returns <0 (with the exception of @ref
+ * POLARIS_TIMED_OUT -- see below), the socket will be closed before the
+ * function returns.
+ *
  * @warning
  * Important: A read timeout is a normal occurrence and is not considered an
  * error condition. Read timeouts can happen occasionally due to intermittent
  * internet connections (e.g., client vehicle losing cell coverage briefly).
  * Most GNSS receivers can tolerate small gaps in corrections data. The socket
- * will _not_ be closed on a read timeout (return 0). The calling code must
- * call `Polaris_Disconnect()` to close the socket before attempting to
- * reconnect or reauthenticate.
+ * will _not_ be closed on a read timeout (@ref POLARIS_TIMED_OUT). The calling
+ * code must call `Polaris_Disconnect()` to close the socket before attempting
+ * to reconnect or reauthenticate.
  *
  * @note
  * There is no guarantee that a data block contains a complete RTCM message, or
@@ -379,9 +383,10 @@ int Polaris_RequestBeacon(PolarisContext_t* context, const char* beacon_id);
  *
  * @param context The Polaris context to be used.
  *
- * @return The number of received bytes, or 0 if the timeout elapsed.
+ * @return The number of received bytes.
  * @return @ref POLARIS_CONNECTION_CLOSED if the connection was closed remotely
  *         or by calling @ref Polaris_Disconnect().
+ * @return @ref POLARIS_TIMED_OUT if the socket receive timeout elapsed.
  * @return @ref POLARIS_FORBIDDEN if the connection is closed before any data
  *         is received, indicating an authentication failure (invalid or expired
  *         access token).

--- a/src/point_one/polaris/polaris_interface.h
+++ b/src/point_one/polaris/polaris_interface.h
@@ -268,6 +268,11 @@ class PolarisInterface {
    *
    * If the specified timeout has elapsed since the last time data was received,
    * the connection will be considered lost and the function will return.
+ *
+   * @post
+   * Unlike @ref Polaris_Work(), a value of @ref POLARIS_TIMED_OUT here
+   * indicates the connection has been lost, and the socket will be closed on
+   * return.
    *
    * See also @ref Polaris_Run().
    *

--- a/src/point_one/polaris/polaris_interface.h
+++ b/src/point_one/polaris/polaris_interface.h
@@ -223,22 +223,35 @@ class PolarisInterface {
    * POLARIS_RECV_TIMEOUT_MS elapses. If @ref Disconnect() is called, this
    * function will return immediately.
    *
+   * If an error occurs and this function returns <0 (with the exception of @ref
+   * POLARIS_TIMED_OUT -- see below), the socket will be closed before the
+   * function returns.
+   *
+   * @warning
+   * Important: A read timeout is a normal occurrence and is not considered an
+   * error condition. Read timeouts can happen occasionally due to intermittent
+   * internet connections (e.g., client vehicle losing cell coverage briefly).
+   * Most GNSS receivers can tolerate small gaps in corrections data. The socket
+   * will _not_ be closed on a read timeout (@ref POLARIS_TIMED_OUT). The
+   * calling code must call `Disconnect()` to close the socket before attempting
+   * to reconnect or reauthenticate.
+   *
    * @note
    * There is no guarantee that a data block contains a complete RTCM message,
    * or starts on an RTCM message boundary.
    *
    * @post
    * The received data will be stored in the data buffer on return (@ref
-   *  GetRecvBuffer()). If a callback function is registered (@ref
-   *  SetRTCMCallback()), it will be called he the received data before this
-   *  function returns.
+   * GetRecvBuffer()). If a callback function is registered (@ref
+   * SetRTCMCallback()), it will be called he the received data before this
+   * function returns.
    *
    * See also @ref Polaris_Work().
    *
-   * @return The number of received bytes, or 0 if the timeout elapsed or @ref
-   *         Disconnect() was called without receiving data.
+   * @return The number of received bytes.
    * @return @ref POLARIS_CONNECTION_CLOSED if the connection was closed
-   *         remotely.
+   *         remotely or by calling @ref Disconnect().
+   * @return @ref POLARIS_TIMED_OUT if the socket receive timeout elapsed.
    * @return @ref POLARIS_FORBIDDEN if the connection is closed before any data
    *         is received, indicating an authentication failure (invalid or
    *         expired access token).
@@ -262,7 +275,9 @@ class PolarisInterface {
    *        reads, after which the connection is considered lost.
    *
    * @return @ref POLARIS_SUCCESS if the connection was closed by a call to @ref
-   *         Disconnect().
+   *         Disconnect(). Note that this differs from @ref Work(), which
+   *         returns @ref POLARIS_CONNECTION_CLOSED for both remote and local
+   *         connection termination.
    * @return @ref POLARIS_CONNECTION_CLOSED if the connection was closed
    *         remotely.
    * @return @ref POLARIS_TIMED_OUT if no data was received for the specified


### PR DESCRIPTION
`Polaris_Work()` now returns `POLARIS_TIMED_OUT` on a socket read timeout, and `POLARIS_CONNECTION_CLOSED` when the connection is terminated either remotely or via `Polaris_Disconnect()`. Previously, it returned 0 for both conditions. It should no longer return 0 under any circumstances.