### PR TITLE
Be more robust in the face of network errors.

### DIFF
--- a/c/examples/connection_retry.c
+++ b/c/examples/connection_retry.c
@@ -21,7 +21,7 @@ void HandleSignal(int sig) {
   signal(sig, SIG_DFL);
 
   P1_printf("Caught signal %s (%d). Closing Polaris connection.\n",
-            sys_siglist[sig], sig);
+            strsignal(sig), sig);
   Polaris_Disconnect(&context);
 }
 

--- a/c/examples/simple_polaris_client.c
+++ b/c/examples/simple_polaris_client.c
@@ -21,7 +21,7 @@ void HandleSignal(int sig) {
   signal(sig, SIG_DFL);
 
   P1_printf("Caught signal %s (%d). Closing Polaris connection.\n",
-            sys_siglist[sig], sig);
+            strsignal(sig), sig);
   Polaris_Disconnect(&context);
 }
 

--- a/c/src/point_one/polaris/socket_freertos.h
+++ b/c/src/point_one/polaris/socket_freertos.h
@@ -62,25 +62,3 @@ typedef BaseType_t P1_RecvSize_t;
       ((((uint32_t)(x)) & 0x00ff0000UL) >> 8) | ((((uint32_t)(x))) >> 24)))
 # define le32toh(x) htole32(x)
 #endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-static inline int P1_SetAddress(const char* hostname, int port,
-                                P1_SocketAddrV4_t* result) {
-  uint32_t ip = FreeRTOS_gethostbyname(hostname);
-  if (ip == 0) {
-    return -1;
-  }
-  else {
-    result->sin_family = AF_INET;
-    result->sin_port = FreeRTOS_htons(port);
-    result->sin_addr = ip;
-    return 0;
-  }
-}
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/c/src/point_one/polaris/socket_posix.h
+++ b/c/src/point_one/polaris/socket_posix.h
@@ -24,25 +24,3 @@ typedef struct sockaddr_in P1_SocketAddrV4_t;
 typedef struct sockaddr P1_SocketAddr_t;
 
 typedef ssize_t P1_RecvSize_t;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-static inline int P1_SetAddress(const char* hostname, int port,
-                                P1_SocketAddrV4_t* result) {
-  struct hostent* host_info = gethostbyname(hostname);
-  if (host_info == NULL) {
-    return -1;
-  }
-  else {
-    result->sin_family = AF_INET;
-    result->sin_port = htons(port);
-    memcpy(&result->sin_addr, host_info->h_addr_list[0], host_info->h_length);
-    return 0;
-  }
-}
-
-#ifdef __cplusplus
-} // extern "C"
-#endif

--- a/examples/simple_polaris_client.cc
+++ b/examples/simple_polaris_client.cc
@@ -42,7 +42,7 @@ void ReceivedData(const uint8_t* data, size_t length) {
 void HandleSignal(int sig) {
   signal(sig, SIG_DFL);
 
-  LOG(INFO) << "Caught signal " << sys_siglist[sig] << " (" << sig
+  LOG(INFO) << "Caught signal " << strsignal(sig) << " (" << sig
             << "). Closing Polaris connection.";
   polaris_client->Disconnect();
 }

--- a/src/point_one/polaris/polaris_client.h
+++ b/src/point_one/polaris/polaris_client.h
@@ -253,6 +253,10 @@ class PolarisClient {
  private:
   enum class RequestType { NONE, ECEF, LLA, BEACON };
 
+  /**
+   * This mutex_ locks members of this class, except for the position-related
+   * fields below.
+   */
   std::recursive_mutex mutex_;
   PolarisInterface polaris_;
   std::atomic<bool> running_;
@@ -274,6 +278,12 @@ class PolarisClient {
   std::string api_key_;
   std::string unique_id_;
 
+  /**
+   * position_mutex_ protects access to the four position-related members below.
+   * When locking both mutex_ and position_mutex_, in order to prevent possible
+   * deadlock, always lock mutex_ first.
+   */
+  std::mutex position_mutex_;
   RequestType current_request_type_ = RequestType::NONE;
   double ecef_position_m_[3] = {NAN, NAN, NAN};
   double lla_position_deg_[3] = {NAN, NAN, NAN};


### PR DESCRIPTION
# Changes
- Treat failures of `SSL_connect()` as temporary (retry-able) failures, not fatal errors.
- Wait two seconds after a failed reconnect attempt before the next try.
- `SendxxxPosition()` and `RequestBeacon()` no longer block while `PolarisClient::Run()` has things locked.
  - Intermittent network connectivity may keep the PolarisClient instance locked for long periods during (re-)connecting waiting on network timeouts.
- Log when `PolarisClient::Run()` exits due to fatal error.
- Fixed build failure due to Glibc's obsolete `sys_siglist[]`.