### PR TITLE
Updated external CMake project examples to reference git repo.

### DIFF
--- a/c/examples/external_cmake_project/CMakeLists.txt
+++ b/c/examples/external_cmake_project/CMakeLists.txt
@@ -37,9 +37,8 @@ project(polaris_usage_example C)
 include(FetchContent)
 FetchContent_Declare(
     polaris
-    #GIT_REPOSITORY https://github.com/PointOneNav/polaris.git
-    #GIT_TAG v1.3.1
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../..
+    GIT_REPOSITORY https://github.com/PointOneNav/polaris.git
+    GIT_TAG v1.3.1
     SOURCE_SUBDIR c
 )
 set(POLARIS_BUILD_EXAMPLES OFF CACHE INTERNAL "")

--- a/examples/external_cmake_project/CMakeLists.txt
+++ b/examples/external_cmake_project/CMakeLists.txt
@@ -37,9 +37,8 @@ project(polaris_usage_example C CXX)
 include(FetchContent)
 FetchContent_Declare(
     polaris
-    #GIT_REPOSITORY https://github.com/PointOneNav/polaris.git
-    #GIT_TAG v1.3.1
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../..
+    GIT_REPOSITORY https://github.com/PointOneNav/polaris.git
+    GIT_TAG v1.3.1
 )
 set(POLARIS_BUILD_EXAMPLES OFF CACHE INTERNAL "")
 FetchContent_MakeAvailable(polaris)


### PR DESCRIPTION
The FetchContent support was fixed in release 1.3.1, so these files could not be updated until after that release.