### PR TITLE
Fixed sizeof() call in P1_PrintData().

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -51,6 +51,11 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         echo "CXX=/usr/bin/${{ matrix.compiler }}" >> $GITHUB_ENV
+        if [[ "${{ matrix.compiler }}" == "clang++" ]]; then
+          echo "CC=/usr/bin/clang" >> $GITHUB_ENV
+        else
+          echo "CC=/usr/bin/gcc" >> $GITHUB_ENV
+        fi
         echo "EXT=" >> $GITHUB_ENV
         # Just for Github action builds set USE_BAZEL_VERSION to override the
         # bazelversion file so we can test different Bazel versions even though
@@ -224,6 +229,11 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         echo "CXX=/usr/bin/${{ matrix.compiler }}" >> $GITHUB_ENV
+        if [[ "${{ matrix.compiler }}" == "clang++" ]]; then
+          echo "CC=/usr/bin/clang" >> $GITHUB_ENV
+        else
+          echo "CC=/usr/bin/gcc" >> $GITHUB_ENV
+        fi
         echo "EXT=" >> $GITHUB_ENV
         # Just for Github action builds set USE_BAZEL_VERSION to override the
         # bazelversion file so we can test different Bazel versions even though

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -30,6 +30,10 @@ jobs:
             os: ubuntu-latest
             tool: bazel-6.5.0
             compiler: g++
+          - arch: x64
+            os: ubuntu-latest
+            tool: cmake
+            compiler: clang++
           # Windows not currently supported by C++ library.
           #- arch: x64
           #  os: windows-latest
@@ -206,12 +210,16 @@ jobs:
         os: [ubuntu-latest]
         tool: [make, cmake, bazel-4.2.2, bazel-6.5.0]
         compiler: [g++]
-        #include:
-        #   Windows not currently supported by C library.
-        #  - arch: x64
-        #    os: windows-latest
-        #    tool: cmake
-        #    compiler: msvc
+        include:
+          - arch: x64
+            os: ubuntu-latest
+            tool: cmake
+            compiler: clang++
+          # Windows not currently supported by C library.
+          #- arch: x64
+          #  os: windows-latest
+          #  tool: cmake
+          #  compiler: msvc
     defaults:
       run:
         shell: bash

--- a/c/src/point_one/polaris/polaris.c
+++ b/c/src/point_one/polaris/polaris.c
@@ -1385,7 +1385,7 @@ void P1_PrintData(const uint8_t* buffer, size_t length) {
     }
 
     str_length +=
-        snprintf(str + str_length, sizeof(str - str_length), "%02x", buffer[i]);
+        snprintf(str + str_length, sizeof(str) - str_length, "%02x", buffer[i]);
 
     if (i % 16 == 15) {
       str[str_length++] = '\0';


### PR DESCRIPTION
# Changes
- Include `clang` in list of compilers tested by CI

# Fixes
- Fixed incorrect `sizeof()` call in `P1_PrintData()`